### PR TITLE
Proper Xcode 5 support

### DIFF
--- a/cibuild
+++ b/cibuild
@@ -58,17 +58,16 @@ build_scheme ()
 {
     local scheme=$1
 
-    run_xcodebuild -scheme "$scheme" -n test 2>&1 1>/dev/null | awk -f "$SCRIPT_DIR/xcodebuild.awk"
+    run_xcodebuild -scheme "$scheme" test 2>&1 | awk -f "$SCRIPT_DIR/xcodebuild.awk"
+    local awkstatus=$?
 
-    # Check whether this scheme supports the `test` action.
-    if [ "$?" -eq "2" ]
+    # If this scheme doesn't support the `test` action, try again with `build`.
+    if [ "$awkstatus" -eq "2" ]
     then
         run_xcodebuild -scheme "$scheme" build 2>&1 | awk -f "$SCRIPT_DIR/xcodebuild.awk"
-    else
-        run_xcodebuild -scheme "$scheme" test 2>&1 | awk -f "$SCRIPT_DIR/xcodebuild.awk"
+        awkstatus=$?
     fi
 
-    local awkstatus=$?
     local xcstatus=${PIPESTATUS[0]}
 
     if [ "$xcstatus" -eq "65" ]

--- a/cibuild
+++ b/cibuild
@@ -65,25 +65,27 @@ build_scheme ()
     run_xcodebuild -scheme "$scheme" test | parse_build
 
     local awkstatus=$?
+    local xcstatus=${PIPESTATUS[0]}
     local sdkflag=
 
     # If this scheme targets iOS, try building for the simulator.
     if [ "$awkstatus" -eq "3" ]
     then
         sdkflag="-sdk iphonesimulator"
-
         run_xcodebuild $sdkflag -scheme "$scheme" test | parse_build
+
         awkstatus=$?
+        xcstatus=${PIPESTATUS[0]}
     fi
 
     # If this scheme doesn't support the `test` action, try again with `build`.
     if [ "$awkstatus" -eq "2" ]
     then
         run_xcodebuild $sdkflag -scheme "$scheme" build | parse_build
-        awkstatus=$?
-    fi
 
-    local xcstatus=${PIPESTATUS[0]}
+        awkstatus=$?
+        xcstatus=${PIPESTATUS[0]}
+    fi
 
     if [ "$xcstatus" -eq "65" ]
     then
@@ -137,8 +139,8 @@ else
     echo -e "*** The following targets will be built:\n$targets"
     echo "*** Building..."
 
-    echo "$targets" | while read scheme
+    echo "$targets" | while read line
     do
-        build_scheme "$scheme" || exit $?
+        build_scheme "$line"
     done
 fi

--- a/cibuild
+++ b/cibuild
@@ -40,35 +40,6 @@ XCODEBUILD_SETTINGS="TEST_AFTER_BUILD=YES RUN_CLANG_STATIC_ANALYZER=NO"
 ## Build Process
 ##
 
-if [ -z "$*" ]
-then
-    # lol recursive shell script
-    if [ -n "$DEFAULT_TARGETS" ]
-    then
-        echo "$DEFAULT_TARGETS" | xargs "$SCRIPT_DIR/cibuild"
-    else
-        xcodebuild -list | awk -f "$SCRIPT_DIR/targets.awk" | xargs "$SCRIPT_DIR/cibuild"
-    fi
-
-    exit $?
-fi
-
-if [ -f "$BOOTSTRAP" ]
-then
-    echo "*** Bootstrapping..."
-    bash "$BOOTSTRAP" || exit $?
-fi
-
-echo "*** The following targets will be built:"
-
-for target in "$@"
-do
-    echo "$target"
-done
-
-echo "*** Cleaning all targets..."
-xcodebuild -alltargets -configuration "$XCCONFIGURATION" clean OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS
-
 run_xcodebuild ()
 {
     local scheme=$1
@@ -106,9 +77,38 @@ build_scheme ()
     return $xcstatus
 }
 
-echo "*** Building..."
+build_targets ()
+{
+    echo "*** The following targets will be built:"
 
-for scheme in "$@"
-do
-    build_scheme "$scheme" || exit $?
-done
+    for target in "$@"
+    do
+        echo "$target"
+    done
+
+    echo "*** Cleaning all targets..."
+    xcodebuild -alltargets -configuration "$XCCONFIGURATION" clean OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS
+
+    echo "*** Building..."
+
+    for scheme in "$@"
+    do
+        build_scheme "$scheme" || exit $?
+    done
+}
+
+if [ -f "$BOOTSTRAP" ]
+then
+    echo "*** Bootstrapping..."
+    bash "$BOOTSTRAP" || exit $?
+fi
+
+if [ "$#" -ne "0" ]
+then
+    build_targets "$@"
+elif [ -n "$DEFAULT_TARGETS" ]
+then
+    build_targets $DEFAULT_TARGETS
+else
+    build_targets $(xcodebuild -list | awk -f "$SCRIPT_DIR/targets.awk")
+fi

--- a/cibuild
+++ b/cibuild
@@ -123,7 +123,7 @@ then
 fi
 
 echo "*** Cleaning all targets..."
-xcodebuild -alltargets -configuration "$XCCONFIGURATION" clean OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS
+xcodebuild -alltargets -configuration "$XCCONFIGURATION" clean OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS 2>&1 >/dev/null
 
 if [ "$#" -ne "0" ]
 then

--- a/cibuild
+++ b/cibuild
@@ -43,9 +43,9 @@ run_xcodebuild ()
 {
     if [ -n "$XCWORKSPACE" ]
     then
-        xcodebuild -workspace "$XCWORKSPACE" -configuration "$XCCONFIGURATION" "$@" OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS
+        xcodebuild -workspace "$XCWORKSPACE" -configuration "$XCCONFIGURATION" "$@" OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS 2>&1
     else
-        xcodebuild -configuration "$XCCONFIGURATION" "$@" OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS
+        xcodebuild -configuration "$XCCONFIGURATION" "$@" OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS 2>&1
     fi
 
     local status=$?
@@ -53,17 +53,33 @@ run_xcodebuild ()
     return $status
 }
 
+parse_build ()
+{
+    awk -f "$SCRIPT_DIR/xcodebuild.awk"
+}
+
 build_scheme ()
 {
     local scheme=$1
 
-    run_xcodebuild -scheme "$scheme" test 2>&1 | awk -f "$SCRIPT_DIR/xcodebuild.awk"
+    run_xcodebuild -scheme "$scheme" test | parse_build
+
     local awkstatus=$?
+    local sdkflag=
+
+    # If this scheme targets iOS, try building for the simulator.
+    if [ "$awkstatus" -eq "3" ]
+    then
+        sdkflag="-sdk iphonesimulator"
+
+        run_xcodebuild $sdkflag -scheme "$scheme" test | parse_build
+        awkstatus=$?
+    fi
 
     # If this scheme doesn't support the `test` action, try again with `build`.
     if [ "$awkstatus" -eq "2" ]
     then
-        run_xcodebuild -scheme "$scheme" build 2>&1 | awk -f "$SCRIPT_DIR/xcodebuild.awk"
+        run_xcodebuild $sdkflag -scheme "$scheme" build | parse_build
         awkstatus=$?
     fi
 

--- a/cibuild
+++ b/cibuild
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 SCRIPT_DIR=$(dirname "$0")
-cd "$SCRIPT_DIR/.."
 
 ##
 ## Configuration Variables

--- a/cibuild
+++ b/cibuild
@@ -106,9 +106,6 @@ build_targets ()
         echo "$target"
     done
 
-    echo "*** Cleaning all targets..."
-    xcodebuild -alltargets -configuration "$XCCONFIGURATION" clean OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS
-
     echo "*** Building..."
 
     for scheme in "$@"
@@ -117,11 +114,16 @@ build_targets ()
     done
 }
 
+export -f build_targets
+
 if [ -f "$BOOTSTRAP" ]
 then
     echo "*** Bootstrapping..."
     bash "$BOOTSTRAP" || exit $?
 fi
+
+echo "*** Cleaning all targets..."
+xcodebuild -alltargets -configuration "$XCCONFIGURATION" clean OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS
 
 if [ "$#" -ne "0" ]
 then
@@ -130,5 +132,13 @@ elif [ -n "$DEFAULT_TARGETS" ]
 then
     build_targets $DEFAULT_TARGETS
 else
-    build_targets $(xcodebuild -list | awk -f "$SCRIPT_DIR/targets.awk")
+    targets=$(xcodebuild -list | awk -f "$SCRIPT_DIR/targets.awk")
+
+    echo -e "*** The following targets will be built:\n$targets"
+    echo "*** Building..."
+
+    echo "$targets" | while read scheme
+    do
+        build_scheme "$scheme" || exit $?
+    done
 fi

--- a/cibuild
+++ b/cibuild
@@ -34,7 +34,7 @@ BOOTSTRAP="$SCRIPT_DIR/bootstrap"
 DEFAULT_TARGETS=
 
 # Extra build settings to pass to xcodebuild.
-XCODEBUILD_SETTINGS="TEST_AFTER_BUILD=YES RUN_CLANG_STATIC_ANALYZER=NO"
+XCODEBUILD_SETTINGS="RUN_CLANG_STATIC_ANALYZER=NO"
 
 ##
 ## Build Process
@@ -42,13 +42,11 @@ XCODEBUILD_SETTINGS="TEST_AFTER_BUILD=YES RUN_CLANG_STATIC_ANALYZER=NO"
 
 run_xcodebuild ()
 {
-    local scheme=$1
-
     if [ -n "$XCWORKSPACE" ]
     then
-        xcodebuild -workspace "$XCWORKSPACE" -scheme "$scheme" -configuration "$XCCONFIGURATION" build OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS
+        xcodebuild -workspace "$XCWORKSPACE" -configuration "$XCCONFIGURATION" "$@" OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS
     else
-        xcodebuild -scheme "$scheme" -configuration "$XCCONFIGURATION" build OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS
+        xcodebuild -configuration "$XCCONFIGURATION" "$@" OBJROOT="$PWD/build" SYMROOT="$PWD/build" $XCODEBUILD_SETTINGS
     fi
 
     local status=$?
@@ -60,7 +58,15 @@ build_scheme ()
 {
     local scheme=$1
 
-    run_xcodebuild "$scheme" 2>&1 | awk -f "$SCRIPT_DIR/xcodebuild.awk"
+    run_xcodebuild -scheme "$scheme" -n test 2>&1 1>/dev/null | awk -f "$SCRIPT_DIR/xcodebuild.awk"
+
+    # Check whether this scheme supports the `test` action.
+    if [ "$?" -eq "2" ]
+    then
+        run_xcodebuild -scheme "$scheme" build 2>&1 | awk -f "$SCRIPT_DIR/xcodebuild.awk"
+    else
+        run_xcodebuild -scheme "$scheme" test 2>&1 | awk -f "$SCRIPT_DIR/xcodebuild.awk"
+    fi
 
     local awkstatus=$?
     local xcstatus=${PIPESTATUS[0]}

--- a/targets.awk
+++ b/targets.awk
@@ -7,6 +7,6 @@ BEGIN {
         if ($0 ~ /Tests/) continue;
 
         sub(/^ +/, "");
-        print "'" $0 "'";
+        print;
     }
 }

--- a/targets.awk
+++ b/targets.awk
@@ -4,7 +4,7 @@ BEGIN {
 
 /Targets:/ {
     while (getline && $0 != "") {
-        if ($0 ~ /Tests/) continue;
+        if ($0 ~ /Test/) continue;
 
         sub(/^ +/, "");
         print;

--- a/xcodebuild.awk
+++ b/xcodebuild.awk
@@ -2,7 +2,8 @@
 #
 # 0 - No errors found.
 # 1 - Build or test failure. Errors will be logged automatically.
-# 2 - Untestable target. Retry with the "build" action.
+# 2 - Untestable target. Retry with the `build` action.
+# 3 - Wrong SDK. Retry with SDK `iphonesimulator`.
 
 BEGIN {
     status = 0;
@@ -13,13 +14,12 @@ BEGIN {
     fflush(stdout);
 }
 
-/is not testable/ {
-    status = 2;
-    exit;
-}
-
 /[0-9]+: (error|warning):/ {
     errors = errors $0 "\n";
+}
+
+/is not testable/ {
+    status = 2;
 }
 
 /(TEST|BUILD) FAILED/ {
@@ -28,6 +28,10 @@ BEGIN {
 
 /does not contain a scheme named/ {
     status = 1;
+}
+
+/cannot run using the selected device/ {
+    status = 3;
 }
 
 END {

--- a/xcodebuild.awk
+++ b/xcodebuild.awk
@@ -14,7 +14,8 @@ BEGIN {
 }
 
 /is not testable/ {
-    exit 2;
+    status = 2;
+    exit;
 }
 
 /[0-9]+: (error|warning):/ {

--- a/xcodebuild.awk
+++ b/xcodebuild.awk
@@ -13,7 +13,7 @@ BEGIN {
     fflush(stdout);
 }
 
-/is not valid for Testing/ {
+/is not testable/ {
     exit 2;
 }
 


### PR DESCRIPTION
`TEST_AFTER_BUILD` doesn't do anything on Xcode 5. Instead, try the `test` action, falling back to `build` if that fails.

Also:
- Implemented automatic fallbacks for iOS builds, so hopefully `-sdk iphonesimulator` will get automatically added in most cases. _(This was the number one reason to use a custom `cibuild` script before.)_
- Stopped recursively invoking the script. It's too confusing, so I just factored things out into a function instead.
- Stopped `cd`ing out of the working directory. This could result in a broken `SCRIPT_DIR` if the project file is actually located elsewhere, like in [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa/tree/master/ReactiveCocoaFramework).
