### PR TITLE
Xcode 6.1 support

### DIFF
--- a/schemes.awk
+++ b/schemes.awk
@@ -2,10 +2,8 @@ BEGIN {
     FS = "\n";
 }
 
-/Targets:/ {
+/Schemes:/ {
     while (getline && $0 != "") {
-        if ($0 ~ /Test/) continue;
-
         sub(/^ +/, "");
         print "'" $0 "'";
     }


### PR DESCRIPTION
Look specifically for schemes in `xcodebuild -list`, because targets may not have identical names, and we should prefer schemes.
