### PR TITLE
Bootstrap does not require xctool

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -8,12 +8,6 @@ export SCRIPT_DIR=$(dirname "$0")
 
 main ()
 {
-    if [ -n "$REQUIRED_TOOLS" ]
-    then
-        echo "*** Checking dependencies..."
-        check_deps
-    fi
-
     local submodules=$(git submodule status)
     local result=$?
 
@@ -27,19 +21,6 @@ main ()
         echo "*** Updating submodules..."
         update_submodules
     fi
-}
-
-check_deps ()
-{
-    for tool in $REQUIRED_TOOLS
-    do
-        which -s "$tool"
-        if [ "$?" -ne "0" ]
-        then
-            echo "*** Error: $tool not found. Please install it and bootstrap again."
-            exit 1
-        fi
-    done
 }
 
 bootstrap_submodule ()

--- a/bootstrap
+++ b/bootstrap
@@ -3,25 +3,11 @@
 export SCRIPT_DIR=$(dirname "$0")
 
 ##
-## Configuration Variables
-##
-
-config ()
-{
-    # A whitespace-separated list of executables that must be present and locatable.
-    : ${REQUIRED_TOOLS="xctool"}
-    
-    export REQUIRED_TOOLS
-}
-
-##
 ## Bootstrap Process
 ##
 
 main ()
 {
-    config
-
     if [ -n "$REQUIRED_TOOLS" ]
     then
         echo "*** Checking dependencies..."

--- a/cibuild
+++ b/cibuild
@@ -95,7 +95,7 @@ check_deps ()
         which -s "$tool"
         if [ "$?" -ne "0" ]
             then
-            echo "*** Error: $tool not found. Please install it and bootstrap again."
+            echo "*** Error: $tool not found. Please install it and cibuild again."
             exit 1
         fi
     done

--- a/cibuild
+++ b/cibuild
@@ -41,11 +41,15 @@ config ()
     # Individual names can be quoted to avoid word splitting.
     : ${SCHEMES:=$(xcodebuild -list -project "$XCODEPROJ" 2>/dev/null | awk -f "$SCRIPT_DIR/schemes.awk")}
 
+    # A whitespace-separated list of executables that must be present and locatable.
+    : ${REQUIRED_TOOLS="xctool"}
+
     export XCWORKSPACE
     export XCODEPROJ
     export BOOTSTRAP
     export XCTOOL_OPTIONS
     export SCHEMES
+    export REQUIRED_TOOLS
 }
 
 ##

--- a/cibuild
+++ b/cibuild
@@ -61,7 +61,7 @@ main ()
     config
 
     if [ -n "$REQUIRED_TOOLS" ]
-        then
+    then
         echo "*** Checking dependencies..."
         check_deps
     fi
@@ -94,7 +94,7 @@ check_deps ()
     do
         which -s "$tool"
         if [ "$?" -ne "0" ]
-            then
+        then
             echo "*** Error: $tool not found. Please install it and cibuild again."
             exit 1
         fi

--- a/cibuild
+++ b/cibuild
@@ -60,6 +60,12 @@ main ()
 {
     config
 
+    if [ -n "$REQUIRED_TOOLS" ]
+        then
+        echo "*** Checking dependencies..."
+        check_deps
+    fi
+
     if [ -f "$BOOTSTRAP" ]
     then
         echo "*** Bootstrapping..."
@@ -80,6 +86,19 @@ main ()
 
         exit $status
     )
+}
+
+check_deps ()
+{
+    for tool in $REQUIRED_TOOLS
+    do
+        which -s "$tool"
+        if [ "$?" -ne "0" ]
+            then
+            echo "*** Error: $tool not found. Please install it and bootstrap again."
+            exit 1
+        fi
+    done
 }
 
 find_pattern ()


### PR DESCRIPTION
Fixes #5 such that:
- `cibuild` checks for its own dependencies (and thus is usable in the absence of `bootstrap`)
- `bootstrap` no longer depends on `xctool`

NB: I removed the `config` and `check_deps` portions of `bootstrap` entirely since they are now unused.
